### PR TITLE
Webpacker instance config

### DIFF
--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -39,7 +39,7 @@ module React
         end
       else
         def find_asset(logical_path)
-          asset_path = Webpacker.manifest.lookup(logical_path).to_s
+          asset_path = manifest.lookup(logical_path).to_s
           if Webpacker.dev_server.running?
             ds = Webpacker.dev_server
             # Remove the protocol and host from the asset path. Sometimes webpacker includes this, sometimes it does not

--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -40,8 +40,8 @@ module React
       else
         def find_asset(logical_path)
           asset_path = manifest.lookup(logical_path).to_s
-          if Webpacker.dev_server.running?
-            ds = Webpacker.dev_server
+          if webpacker_instance.dev_server.running?
+            ds = webpacker_instance.dev_server
             # Remove the protocol and host from the asset path. Sometimes webpacker includes this, sometimes it does not
             asset_path.slice!("#{ds.protocol}://#{ds.host_with_port}")
             dev_server_asset = open("#{ds.protocol}://#{ds.host_with_port}#{asset_path}").read

--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -53,13 +53,17 @@ module React
         end
       end
 
+      class << self
+        attr_accessor :webpacker_instance
+      end
+
       if MAJOR < 3
         def manifest
           Webpacker::Manifest
         end
       else
         def manifest
-          Webpacker.manifest
+          webpacker_instance.manifest
         end
       end
 
@@ -69,7 +73,15 @@ module React
         end
       else
         def config
-          Webpacker.config
+          webpacker_instance.config
+        end
+      end
+
+      def webpacker_instance
+        if self.class.webpacker_instance.present?
+          self.class.webpacker_instance
+        else
+          Webpacker
         end
       end
 


### PR DESCRIPTION
### Summary

Adds support for specifying a Webpacker instance other than the default one, which is necessary when running multiple instances of webpacker, eg. in a core app _and_ in an engine.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing!
